### PR TITLE
new: added copy to testimonial submission page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ import OpenLetter from "./components/OpenLetter/OpenLetter";
 
 import ContactUs from "./components/ContactUs";
 
-import Testimonial from "./components/Testimonial";
+import TestimonialSubmit from "./components/TestimonialSubmit";
 
 import Analysis from "./components/Analysis";
 
@@ -33,7 +33,7 @@ const App = () => {
           <Route path = "/Letter" component = { OpenLetter } />
           <Route path = "/Contact" component = { ContactUs } />
           <Route path = "/Analysis" component = { Analysis } />
-          <Route path = "/Testimonial" component = { Testimonial } />
+          <Route path = "/Submit_Testimonial" component = { TestimonialSubmit } />
         </Switch>
         <Footer />
       </React.Fragment>

--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -5,35 +5,13 @@ const Footer = () => {
   return (
     <footer className={styles.footer}>
       <div className="container-fluid">
-        <div className="row justify-content-around">
+        <div className="row justify-content-around pb-3">
           <div className="col-8 col-md-5">
             <p className={styles.description}>
               View the code for this website on <a href="https://github.com/upetition/Stop-uOttawa-Surveillance">GitHub</a>
             </p>
           </div>
           <div className="col-2">
-            <ul className="list-unstyled">
-              <li>
-                <a className={styles.footerlink} href="/petition">
-                  Petition
-                </a>
-              </li>
-              <li>
-                <a className={styles.footerlink} href="/privacy">
-                  Privacy
-                </a>
-              </li>
-              <li>
-                <a className={styles.footerlink} href="/letter">
-                  Open Letter
-                </a>
-              </li>
-              <li>
-                <a className={styles.footerlink} href="/contact">
-                  Contact
-                </a>
-              </li>
-            </ul>
           </div>
         </div>
       </div>

--- a/src/components/NavBar/index.jsx
+++ b/src/components/NavBar/index.jsx
@@ -20,9 +20,10 @@ const ButtonLink = ({ to, className, children }) => {
 
 const NavBar = () => {
   const [anchorResource, setAnchorResource] = useState(null);
+  const [anchorContact, setAnchorContact] = useState(null);
 
-  const handleResourceClose = () => setAnchorResource(null);
-  const handleResourceClick = (event) => setAnchorResource(event.currentTarget);
+  const handleMenuClose = (setter) => () => setter(null);
+  const handleMenuClick = (setter) => (event) => setter(event.currentTarget);
 
   return (
     <React.Fragment>
@@ -42,32 +43,46 @@ const NavBar = () => {
           </ButtonLink>
           <Button
             className="text-capitalize font-weight-normal navbar-light nav-item nav-link active"
-            onClick={handleResourceClick}
+            onClick={handleMenuClick(setAnchorResource)}
           >
             Resources
           </Button>
-          <ButtonLink to="Contact">
+          <Button
+            className="text-capitalize font-weight-normal navbar-light nav-item nav-link active"
+            onClick={handleMenuClick(setAnchorContact)}
+          >
             Contact
-          </ButtonLink>
+          </Button>
         </div>
         <Menu
           id="resource-menu"
           anchorEl={anchorResource}
-          onClose={handleResourceClose}
+          onClose={handleMenuClose(setAnchorResource)}
           open={Boolean(anchorResource)}
           keepMounted
-          className="navbar navbar-expand-sm navbar-light"
+          className="navbar navbar-light navbar-expand-sm"
         >
-          <MenuItem component={Link} to="/letter" onClick={handleResourceClose}>
+          <MenuItem component={Link} onClose={handleMenuClose(setAnchorResource)} to="/letter">
             Open Letter
           </MenuItem>
-          <MenuItem component={Link} to="/analysis" onClick={handleResourceClose}>
+          <MenuItem component={Link} onClose={handleMenuClose(setAnchorResource)} to="/analysis">
             Policy Analysis
           </MenuItem>
-          <MenuItem component={Link} to="/testimonial" onClick={handleResourceClose}>
+        </Menu>
+        <Menu
+          id="contact-menu"
+          anchorEl={anchorContact}
+          onClose={handleMenuClose(setAnchorContact)}
+          open={Boolean(anchorContact)}
+          keepMounted
+          className="navbar navbar-light navbar-expand-sm"
+        >
+          <MenuItem component={Link} onClose={handleMenuClose(setAnchorContact)} to="/contact">
+            Contact Us
+          </MenuItem>
+          <MenuItem component={Link} onClose={handleMenuClose(setAnchorContact)} to="/submit_testimonial">
             Submit Testimonial
           </MenuItem>
-
         </Menu>
       </nav>
     </React.Fragment>

--- a/src/components/TestimonialSubmit/index.jsx
+++ b/src/components/TestimonialSubmit/index.jsx
@@ -11,13 +11,13 @@ import {
     Card
 } from "@material-ui/core";
 import MuiAlert from "@material-ui/lab/Alert";
-import styles from "./testimonial.module.css";
+import styles from "./testimonialsubmit.module.css";
 
 function Alert(props) {
     return <MuiAlert elevation={6} variant="filled" {...props} />;
   }
 
-const Testimonial = () => {
+const TestimonialSubmit = () => {
   const [name, setName] = useState("");
   const [studentNumber, setStudentNumber] = useState("");
   const [program, setProgram] = useState("");
@@ -135,7 +135,7 @@ const Testimonial = () => {
         <div className={`container ${styles.contentSize} pb-5`}>
             <div className="row pt-5 pb-2">
                 <h1>
-                    Title here
+                    Submit a Testimonial
                 </h1>
             </div>
             <Card
@@ -144,7 +144,8 @@ const Testimonial = () => {
                 <div className="container m-0 p-2 pb-5">
                     <div className="row justify-content-left pb-3">
                         <p className={`${styles.caption}`}>
-                            Description here
+                            If you are a University of Ottawa student who has signed the petition, we would love to hear your thoughts! Comments submitted in this form will be subject to review by the uPetition team and, if they are accepted, will be displayed on our Testimonials page.<br /><br />
+                            Note: Our Testimonials page is currently under construction, but the team is collecting student thoughts while we build!
                         </p>
                     </div>
                     <div className="row justify-content-center p-0 pb-3">
@@ -265,4 +266,4 @@ const Testimonial = () => {
       </main>
   );
 }
-export default Testimonial;
+export default TestimonialSubmit;

--- a/src/components/TestimonialSubmit/testimonialsubmit.module.css
+++ b/src/components/TestimonialSubmit/testimonialsubmit.module.css
@@ -5,5 +5,5 @@
 }
 
 .caption {
-    font-size: 14pt;
+    font-size: 12pt;
 }


### PR DESCRIPTION
## Adding copy to the testimonials page

![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/upetition/Stop-uOttawa-Surveillance/52)

<!-- Link an issue -->
resolves #41 -> Adds copy to the page

<!-- Add at least one reviewer and tag them here -->
Reviewers: @aMahanna @DudeRandom21 

Description:
<!-- Add a small, meaningful description of the PR -->

Adds copy text to the testimonial submission page, moves the testimonial submission from the resources menu to the contact menu (sorry @aMahanna you were right about where to place it before), renames the Testimonials component to TestimonialSubmit, changes the route for the testimonial submission, and as an added bonus it removes the links from the footer since they no longer really make sense.

This PR is made as a draft since the copy is still under review.



<img width="692" alt="Screen Shot 2020-07-18 at 12 01 42 AM" src="https://user-images.githubusercontent.com/23022343/87844297-df42e780-c889-11ea-8f28-272d313be16c.png">